### PR TITLE
增加高级用法: case 可以返回函数

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ var case = function(lastBody, lastRes) {
 var case = async () => {
   const user = await Model.findOne({ where: { id: 1 } });
 
+    // If the function is returned, it will be called.
     return () => {
       const { age } = user;
 

--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ Restspec.prototype.testCase = function(_case, callback) {
     const err = _case();
 
     if (err) return callback(err);
+
     return callback();
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "integrity": "sha1-086gTWsBeyiUrWkED+yLYj60vVI=",
       "requires": {
         "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
+        "fast-json-stable-stringify": "^2.0.0",
         "uri-js": "^4.2.2"
       }
     },


### PR DESCRIPTION
在实际使用中经常执行函数判断结果，但异步中的 `assert` 并不生效，所以增加了新的高级用法。

合并前生效的情况
```js
const case = () => {
  assert.equal(1, 2);
}
```
不生效的情况
```js
const case = async () => {
    return new Promise(resolve => {
      assert.equal(2, 3); // promise 中的 assert 无法在测试框架中正常工作
      resolve();
    });
  }
```

